### PR TITLE
Update orbs and Clojure versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@dev:first
-  clojure: lambdaisland/clojure@dev:first
+  kaocha: lambdaisland/kaocha@0.0.2
+  clojure: lambdaisland/clojure@0.0.6
 
 commands:
   checkout_and_run:
@@ -22,7 +22,7 @@ commands:
 jobs:
   java-11-clojure-1_10:
     executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   java-11-clojure-1_9:
     executor: clojure/openjdk11
@@ -30,7 +30,7 @@ jobs:
 
   java-9-clojure-1_10:
     executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   java-9-clojure-1_9:
     executor: clojure/openjdk9
@@ -38,7 +38,7 @@ jobs:
 
   java-8-clojure-1_10:
     executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   java-8-clojure-1_9:
     executor: clojure/openjdk8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,14 @@ commands:
       - kaocha/upload_codecov
 
 jobs:
+  java-16-clojure-1_10:
+    executor: clojure/openjdk16
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
+
+  java-16-clojure-1_9:
+    executor: clojure/openjdk16
+    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
+    
   java-11-clojure-1_10:
     executor: clojure/openjdk11
     steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
@@ -47,6 +55,8 @@ jobs:
 workflows:
   kaocha_test:
     jobs:
+      - java-16-clojure-1_10
+      - java-16-clojure-1_9
       - java-11-clojure-1_10
       - java-11-clojure-1_9
       - java-9-clojure-1_10


### PR DESCRIPTION
Update CircleCI configuration to use our latest orbs, plus the latest version of Clojure 1.10 (instead of the release candidate).